### PR TITLE
Expose slideTo speed on the API

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,9 +150,11 @@ $('.peppermint').Peppermint({
 
 ##API
 
-Peppermint exposes a set of functions upon installation. These functions can be used to controll the slider externally:
+Peppermint exposes a set of functions upon installation. These functions can be used to control the slider externally:
 
 `slideTo(n)` – change active slide to `n`;
+
+`slideTo(n, speed)` – change active slide to `n` with transition speed in ms. Passing a speed of 0 disables the transition;
 
 `next()` – next slide;
 

--- a/src/peppermint.js
+++ b/src/peppermint.js
@@ -439,8 +439,8 @@ function Peppermint(_this, options) {
 
     //expose the API
     return {
-        slideTo: function(slide) {
-            return changeActiveSlide(parseInt(slide, 10));
+        slideTo: function(slide, speed) {
+            return changeActiveSlide(parseInt(slide, 10), speed);
         },
 
         next: nextSlide,


### PR DESCRIPTION
First of all thanks for your amazing slider, which I found today. Having looked at a lot of alternatives (20+) I was really happy to stumble on yours, which performs much better than all the others I tested.

I am working on a site where there are a very large number of photos in my slider. In order to manage bandwidth / memory usage I load and unload the photos as the user swipes through the photos. We also provide thumbnails to skip directly to a later photo which I implement with `slideTo`. Since the photos aren't necessarily loaded it looks a bit janky when it slides past the unloaded photos. This change allows me to disable the sliding transition for this thumbnail case and just swao immediately to the other photo.

I don't know if you left the `speed` parameter off the API for some reason, but I thought I'd submit a PR in case this is useful for anyone else.

Cheers!

